### PR TITLE
Correct  path to the active file folder for cppcheckcmd.cppcheckdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. Run cppcheck for the current cpp file in editor
 2. Get all the issues with higher severity than the setting
-3. Run cppcheck for the cpp files in the fold of current file
+3. Run cppcheck for the cpp files in the folder of current file
 4. Each change on current file will trigger the execution of cppcheck for the file.
 5. Output cppcheck results in CppcheckReport channel of Output window
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "cpptestid",
-	"version": "0.0.1",
+	"name": "cppcheckcmd",
+	"version": "0.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as cross_spawn from 'cross-spawn';
 import * as child_process from 'child_process';
 import * as xmldom from "xmldom";
 import * as xpath from "xpath";
+const path = require('path');
 let settings = vscode.workspace.getConfiguration('cppcheck');
 let oc =  vscode.window.createOutputChannel("CppcheckReport");
 let hightlightstyle = {
@@ -66,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
 		oc.appendLine("cppcheck report for a folder:");
 		let cmdstring: string [] = new Array("cppcheck","--enable=all","--xml");
 		let curdoc = vscode.window.activeTextEditor!.document;
-		cmdstring.push(curdoc.fileName+"\\..");
+		cmdstring.push(path.dirname(curdoc.fileName));
 		let result =  runCmd(cmdstring);
 		console.log("dir result is:" + result.stdout);
 		console.log("dir result error is:" + result.stderr);


### PR DESCRIPTION
The path to the directory of the active file was being incorrectly set, thus the command cppcheckcmd.cppcheckdir was not working as it should.